### PR TITLE
feat(gamePlayer): eager load user in gamePlayer model

### DIFF
--- a/server/api/games.js
+++ b/server/api/games.js
@@ -52,6 +52,7 @@ router.put('/:gameId/addNewPlayer', (req, res, next) => {
       return Promise.all([Game.findById(req.params.gameId), GamePlayer.findAll({ where: { gameId: req.params.gameId } })])
         .then((result) => {
           const [game, players] = result
+          // isolate new player's object from players array. This object will be sent to all players via sockets
           const newPlayer = players.find(player => player.user.id === req.body.playerId)
           if (players.length === game.gametype.maxPlayers) {
             game.update({ open: false })

--- a/server/api/games.js
+++ b/server/api/games.js
@@ -25,10 +25,7 @@ router.get('/:gametypeId', (req, res, next) => {
 // Used to fetch all players in a specific game instanace
 router.get('/:gameId/players', (req, res, next) => {
   GamePlayer.findAll({
-    where: { gameId: req.params.gameId },
-    include: [{
-      model: User,
-    }]
+    where: { gameId: req.params.gameId }
   })
     .then(players => {
       res.status(200).json(players)
@@ -55,6 +52,7 @@ router.put('/:gameId/addNewPlayer', (req, res, next) => {
       return Promise.all([Game.findById(req.params.gameId), GamePlayer.findAll({ where: { gameId: req.params.gameId } })])
         .then((result) => {
           const [game, players] = result
+          const newPlayer = players.find(player => player.user.id === req.body.playerId)
           if (players.length === game.gametype.maxPlayers) {
             game.update({ open: false })
           }

--- a/server/db/models/gamePlayer.js
+++ b/server/db/models/gamePlayer.js
@@ -1,5 +1,6 @@
 const Sequelize = require('sequelize')
 const db = require('../db')
+const User = require('./user')
 
 const GamePlayer = db.define('gamePlayer', {
   gameScore: {
@@ -7,6 +8,10 @@ const GamePlayer = db.define('gamePlayer', {
   },
   finishPosition: {
     type: Sequelize.INTEGER
+  }
+}, {
+  defaultScope: {
+    include: [{model: User}]
   }
 })
 


### PR DESCRIPTION
Changed eager loading of user object on a gamePlayer instance from happening only in the gamePlayers get route to the gamePlayers model.
After creation of a new gamePlayer in the add player to game put route, isolated the new player's user object to eventually be socketed out to players already in the game.
close #114 