### PR TITLE
fix(GameContainer): rename gameplayerId to userId in playerAnswer obj

### DIFF
--- a/client/components/game/GameContainer.js
+++ b/client/components/game/GameContainer.js
@@ -25,7 +25,7 @@ export class GameContainerClass extends Component {
   answerSubmission(event) {
     event.preventDefault()
     let playerQuestionResult = { answer: this.state.clickedAnswer, time: 5, questionId: this.props.game.currentQuestion }
-    let playerAnswer = { answer: this.state.clickedAnswer, score: 0, gamePlayer: this.props.user.id }
+    let playerAnswer = { answer: this.state.clickedAnswer, score: 0, userId: this.props.user.id }
 
     //The below section of code is a temporary score generator with minimal functionality. 
     //This functionality will be moved to GameplayFunctions and expanded upon to take into account time and gametype.


### PR DESCRIPTION
The userId in the playerAnswer object was mislabeled as the gamePlayerId. It's fixed.

close #196 