### PR TITLE
fix(clearGameplayData): add clearPlayerAnswers to functionality

### DIFF
--- a/client/components/game/GameContainer.js
+++ b/client/components/game/GameContainer.js
@@ -258,6 +258,7 @@ const mapDispatchToProps = dispatch => {
       dispatch(clearAllQuestions())
       dispatch(clearQuestionResults())
       dispatch(clearGameData())
+      dispatch(clearAllPlayerAnswers())
     },
     updateGame(updatedItem) {
       dispatch(updateGame(updatedItem))

--- a/client/components/landing/LandingContainer.js
+++ b/client/components/landing/LandingContainer.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom'
 import LandingPres from './LandingPres'
 import LoginToPlayPres from './LoginToPlayPres'
 import JoinGamePres from './JoinGamePres'
-import { getGameThunk} from '../../store'
+import { getGameThunk, clearAllPlayers, clearAllQuestions, clearQuestionResults, clearGameData, clearAllPlayerAnswers } from '../../store'
 import {topOfPageStart} from '../../../HelperFunctions/utilityFunctions'
 import axios from 'axios'
 
@@ -30,6 +30,7 @@ export class LandingContainerClass extends Component {
   componentDidMount() {
     this._mounted = true
     this.fetchGametypes()
+    this.props.clearAllGameplay()
   }
 
   componentWillUnmount() {
@@ -75,6 +76,13 @@ const mapDispatchToProps = dispatch => {
       // This is because we are adding the current player to the game on click.
       const open = maxPlayers !== 1
       dispatch(getGameThunk(gametypeId, playerId, open))
+    },
+    clearAllGameplay() {
+      dispatch(clearAllPlayers())
+      dispatch(clearAllQuestions())
+      dispatch(clearQuestionResults())
+      dispatch(clearGameData())
+      dispatch(clearAllPlayerAnswers())
     }
   }
 }

--- a/server/api/playerQuestionResults.js
+++ b/server/api/playerQuestionResults.js
@@ -5,7 +5,7 @@ module.exports = router
 router.post('/', (req, res, next) => {
   PlayerQuestionResult.bulkCreate(req.body)
     .then(() => {
-      res.status(204)
+      res.status(204).end()
     })
     .catch(next)
 })


### PR DESCRIPTION
Added the clearAllPlayerAnswers function to the clearAllGameplay function to clear player answers from the store. 
The clearAllGameplay function is now run when the GameContainer unmounts and when the LandingContainer mounts.

close #252 #253 