### PR TITLE
Enable google o auth #265

### DIFF
--- a/client/components/user/LoginForm.js
+++ b/client/components/user/LoginForm.js
@@ -10,15 +10,9 @@ const Login = props => {
   return (
     <div className="auth-form space-below-header" onLoad={topOfPageStart()}>
       <div className="auth-button-container">
-        {/*Tooltips to be removed when features are funtional*/}
-        <Popup
-          trigger={<a /*href="/auth/google"*/ className="btn btn-danger btn-sm google-button">Login with Google</a>}
-          position="bottom center"
-          on="hover"
-        >
-          <p className="coming-soon-tooltip">Feature Coming Soon</p>
-        </Popup>
+        <a href="/auth/google" className="btn btn-danger btn-sm google-button">Login with Google</a>
 
+        {/*Tooltips to be removed when features are funtional*/}
         <Popup
           trigger={<a /*href="/auth/facebook"*/ className="btn btn-primary btn-sm facebook-button">Login with Facebook</a>}
           position="bottom center"

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -43,7 +43,11 @@ if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
     failureRedirect: '/login'
   }),
     function(req, res) {
-      res.redirect(`/player-info/${req.user.dataValues.id}`)
+      if (req.user._changed.firstName !== false) {
+        res.redirect('/')
+      } else {
+        res.redirect(`/player-info/${req.user.dataValues.id}`)
+      }
     }
   )
 

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -13,7 +13,8 @@ if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
   const googleConfig = {
     clientID: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackURL: process.env.GOOGLE_CALLBACK
+    callbackURL: process.env.GOOGLE_CALLBACK,
+    userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo'
   }
 
   const strategy = new GoogleStrategy(googleConfig, (token, refreshToken, profile, done) => {


### PR DESCRIPTION
Enabled a player to log in with their google account. 
Updated GoogleStrategy to no longer use deprecated Google+ API.
Redirected player to proper page depending on whether they have signed up or logged in with Google.

close #265 