### PR TITLE
fix(landing): update styling so that footer doesnt cover gametypes

### DIFF
--- a/client/components/landing/JoinGamePres.js
+++ b/client/components/landing/JoinGamePres.js
@@ -2,7 +2,6 @@ import React from 'react'
 /* eslint-disable react/display-name */
 export default (props) => {
   return (
-    <div>
       <div id="landing-game-container">
         <div id="landing-game-content">
           <div onClick={(e) => props.joinGameClick(e, props.gametypeId, props.playerId, props.gametypes)} style={{ cursor: 'pointer' }}>
@@ -12,6 +11,5 @@ export default (props) => {
           </div>
         </div>
       </div>
-    </div>
   )
 }

--- a/client/components/landing/LandingContainer.js
+++ b/client/components/landing/LandingContainer.js
@@ -40,21 +40,24 @@ export class LandingContainerClass extends Component {
   render() {
     return (
       <div className="space-below-header" onLoad={topOfPageStart()}>
-        <img src="../../../images/bbfield.jpg" id="landing-background-image" />
+
         <div id="landing-container">
-          <LandingPres />
-          {
-            !this.props.user.id ? <LoginToPlayPres /> : <div className="container"><div className="row">{this.state.gametypes.map(gametype => {
-              return (
-                gametype.enabled && <div key={gametype.id} className="col-4">
-                  <JoinGamePres gametypeName={gametype.name} gametypeImage={gametype.image} gametypeDescription={gametype.description} gametypeId={gametype.id} playerId={this.props.user.id} joinGameClick={this.props.joinGameClick} gametypes={this.state.gametypes} />
-                </div>
-              )
-            })
+          <img src="../../../images/bbfield.jpg" id="landing-background-image" />
+          <div id="landing-main-content">
+            <LandingPres />
+            {
+              !this.props.user.id ? <LoginToPlayPres /> : <div className="container"><div className="row">{this.state.gametypes.map(gametype => {
+                return (
+                  gametype.enabled && <div key={gametype.id} className="col-4">
+                    <JoinGamePres gametypeName={gametype.name} gametypeImage={gametype.image} gametypeDescription={gametype.description} gametypeId={gametype.id} playerId={this.props.user.id} joinGameClick={this.props.joinGameClick} gametypes={this.state.gametypes} />
+                  </div>
+                )
+              })
+              }
+              </div>
+              </div>
             }
-            </div>
-            </div>
-          }
+          </div>
         </div>
 
       </div>

--- a/index.css
+++ b/index.css
@@ -199,17 +199,21 @@ footer {
 }
 
 #landing-container {
-  position: absolute;
+  position: relative;
   top: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   margin-top: 0;
 }
 
+#landing-main-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 1;
+  position: relative;
+}
 
 #landing-content {
-  margin: 1em;
+  margin: 1em 0 2em 0;
 }
 
  .landing-pres-container h1 {
@@ -471,14 +475,13 @@ footer {
 
 .space-below-header {
   margin-top: 3.65em;
-  position: relative;
-  height: 100%;
 }
 
 #landing-background-image{
   opacity: .80;
   width: 100vw;
   height: 100vh;
+  position: fixed;
 }
 
 #scoringtimer {


### PR DESCRIPTION
Changed the html hierarchy and css styling of the landing page so the footer will never cover the gametype cards and will remain at the bottom of the page without gaps.

close #275 
related #281 